### PR TITLE
Hide public signup links in UI

### DIFF
--- a/application/views/frontend/default-new/footer.php
+++ b/application/views/frontend/default-new/footer.php
@@ -38,7 +38,7 @@
                     <?php endif; ?>
                     <li> <a href="<?php echo site_url('blog'); ?>"><?php echo site_phrase('blog'); ?></a></li>
                     <li><a href="<?php echo site_url('home/courses'); ?>"><?php echo site_phrase('all_courses'); ?></a></li>
-                    <?php if(get_settings('public_signup') == 'enable'): ?>  
+                    <?php if(false && get_settings('public_signup') == 'enable'): ?>  
                     <li><a href="<?php echo site_url('sign_up'); ?>"><?php echo site_phrase('sign_up'); ?></a></li>
                      <?php endif;?>
                     <?php $custom_page_menus = $this->crud_model->get_custom_pages('', 'footer'); ?>

--- a/application/views/frontend/default-new/header_lg_device.php
+++ b/application/views/frontend/default-new/header_lg_device.php
@@ -262,7 +262,7 @@
 
         <?php if(!$user_id): ?>
           <a href="<?php echo site_url('login'); ?>" class="ms-3"> <?php echo get_phrase('Login'); ?></a>
-          <?php if(get_settings('public_signup') == 'enable'): ?>  
+          <?php if(false && get_settings('public_signup') == 'enable'): ?>  
             <a href="<?php echo site_url('sign_up'); ?>" class="ms-3 text-capitalize ctBtn" style="min-width: 70px"> <?php echo get_phrase('Join Now'); ?></a>
           <?php endif;?>
         <?php endif; ?>

--- a/application/views/frontend/default-new/header_sm_device.php
+++ b/application/views/frontend/default-new/header_sm_device.php
@@ -17,7 +17,7 @@
         <div class="offcanvas-header bg-light">
           <button type="button" class="btn-close" data-bs-dismiss="offcanvas" aria-label="Close"></button>
           <div class="offcanves-btn">
-             <?php if(get_settings('public_signup') == 'enable'): ?>  
+             <?php if(false && get_settings('public_signup') == 'enable'): ?>  
               <a href="<?php echo site_url('sign_up'); ?>" class="signUp-btn"><?php echo get_phrase('Sign Up'); ?></a>
              <?php endif;?>
             <a href="<?php echo site_url('login'); ?>" class="logIn-btn"><?php echo get_phrase('Login'); ?></a>

--- a/application/views/frontend/default-new/home_1.php
+++ b/application/views/frontend/default-new/home_1.php
@@ -859,7 +859,9 @@
                             <?php if($this->session->userdata('user_id')): ?>
                                 <a class="btn" href="<?php echo site_url('user/become_an_instructor'); ?>"><?php echo site_phrase('Become an Instructor'); ?></a>
                                 <?php else: ?>
+                                <?php if(false): ?>
                                 <a  class="btn" href="<?php echo site_url('sign_up?instructor=yes'); ?>"><?php echo site_phrase('Become an Instructor'); ?></a>
+                                <?php endif; ?>
                             <?php endif; ?>
                         <?php endif; ?>
                         </div>
@@ -947,9 +949,9 @@
                                 <!-- <img loading="lazy" src="<?php echo base_url('assets/frontend/default-new/image/2.png')?>"> -->
                                 <h1><?php echo site_phrase('join_now_to_start_learning'); ?></h1>
                                 <p><?php echo site_phrase('Learn from our quality instructors!')?> </p>
-                                 <?php if(get_settings('public_signup') == 'enable'): ?>  
-                                   <a href="<?php echo site_url('sign_up'); ?>"><?php echo site_phrase('get_started'); ?></a>
-                                 <?php endif;?>
+                                <?php if(false && get_settings('public_signup') == 'enable'): ?>  
+                                  <a href="<?php echo site_url('sign_up'); ?>"><?php echo site_phrase('get_started'); ?></a>
+                                <?php endif;?>
                             </div>
                         </div>
                         <div class="col-lg-4 col-md-4 col-sm-12 ">
@@ -967,13 +969,9 @@
                                   <!-- <img loading="lazy" src="<?php echo base_url('assets/frontend/default-new/image/2.png')?>"> -->
                                     <h1><?php echo site_phrase('become_a_new_instructor'); ?></h1>
                                     <p><?php echo site_phrase('Teach_thousands_of_students_and_earn_money!')?> </p>
-                                       <?php if(get_settings('public_signup') == 'enable'): ?>  
-                                            <?php if($this->session->userdata('user_id')): ?>
-                                            <a  href="<?php echo site_url('user/become_an_instructor'); ?>"><?php echo site_phrase('join_now'); ?></a>
-                                            <?php else: ?>
-                                                <a  href="<?php echo site_url('sign_up?instructor=yes'); ?>"><?php echo site_phrase('join_now'); ?></a>
-                                            <?php endif; ?>
-                                     <?php endif;?>
+                                       <?php if($this->session->userdata('user_id')): ?>
+                                        <a  href="<?php echo site_url('user/become_an_instructor'); ?>"><?php echo site_phrase('join_now'); ?></a>
+                                       <?php endif; ?>
                                 </div>
                             </div>
                             <div class="col-lg-4 col-md-4 col-sm-12">

--- a/application/views/frontend/default-new/home_2.php
+++ b/application/views/frontend/default-new/home_2.php
@@ -869,7 +869,7 @@
                                 <!-- <img loading="lazy" src="<?php echo base_url('assets/frontend/default-new/image/2.png')?>"> -->
                                 <h1><?php echo site_phrase('Learn from our quality instructors!'); ?></h1>
                                 <p><?php echo site_phrase('Teach_thousands_of_students_and_earn_money!')?> </p>
-                                   <?php if(get_settings('public_signup') == 'enable'): ?>  
+                                  <?php if(false && get_settings('public_signup') == 'enable'): ?>  
                                 <a href="<?php echo site_url('sign_up'); ?>"><?php echo site_phrase('get_started'); ?></a>
                                  <?php endif;?>
                             </div>
@@ -889,7 +889,7 @@
                                   <!-- <img loading="lazy" src="<?php echo base_url('assets/frontend/default-new/image/2.png')?>"> -->
                                     <h1><?php echo site_phrase('become_a_new_instructor'); ?></h1>
                                     <p><?php echo site_phrase('Teach_thousands_of_students_and_earn_money!')?> </p>
-                                      <?php if(get_settings('public_signup') == 'enable'): ?>  
+                                      <?php if(false && get_settings('public_signup') == 'enable'): ?>  
                                             <?php if($this->session->userdata('user_id')): ?>
                                             <a  href="<?php echo site_url('user/become_an_instructor'); ?>"><?php echo site_phrase('join_now'); ?></a>
                                             <?php else: ?>

--- a/application/views/frontend/default-new/home_3.php
+++ b/application/views/frontend/default-new/home_3.php
@@ -848,7 +848,7 @@
                                 <!-- <img loading="lazy" src="<?php echo base_url('assets/frontend/default-new/image/2.png')?>"> -->
                                 <h1><?php echo site_phrase('join_now_to_start_learning'); ?></h1>
                                 <p><?php echo site_phrase('Learn from our quality instructors!')?> </p>
-                                 <?php if(get_settings('public_signup') == 'enable'): ?>  
+                                 <?php if(false && get_settings('public_signup') == 'enable'): ?>  
                                    <a href="<?php echo site_url('sign_up'); ?>"><?php echo site_phrase('get_started'); ?></a>
                                  <?php endif;?>
                             </div>
@@ -868,7 +868,7 @@
                                   <!-- <img loading="lazy" src="<?php echo base_url('assets/frontend/default-new/image/2.png')?>"> -->
                                     <h1><?php echo site_phrase('become_a_new_instructor'); ?></h1>
                                     <p><?php echo site_phrase('Teach_thousands_of_students_and_earn_money!')?> </p>
-                                     <?php if(get_settings('public_signup') == 'enable'): ?>  
+                                     <?php if(false && get_settings('public_signup') == 'enable'): ?>  
                                         <?php if($this->session->userdata('user_id')): ?>
                                         <a  href="<?php echo site_url('user/become_an_instructor'); ?>"><?php echo site_phrase('join_now'); ?></a>
                                         <?php else: ?>

--- a/application/views/frontend/default-new/home_4.php
+++ b/application/views/frontend/default-new/home_4.php
@@ -660,7 +660,7 @@
                                 <!-- <img loading="lazy" src="<?php echo base_url('assets/frontend/default-new/image/2.png')?>"> -->
                                 <h1><?php echo site_phrase('join_now_to_start_learning'); ?></h1>
                                 <p><?php echo site_phrase('Learn from our quality instructors!')?> </p>
-                                 <?php if(get_settings('public_signup') == 'enable'): ?>  
+                                 <?php if(false && get_settings('public_signup') == 'enable'): ?>  
                                     <a href="<?php echo site_url('sign_up'); ?>"><?php echo site_phrase('get_started'); ?></a>
                                    <?php endif;?>
                             </div>
@@ -680,7 +680,7 @@
                                   <!-- <img loading="lazy" src="<?php echo base_url('assets/frontend/default-new/image/2.png')?>"> -->
                                     <h1><?php echo site_phrase('become_a_new_instructor'); ?></h1>
                                     <p><?php echo site_phrase('Teach_thousands_of_students_and_earn_money!')?> </p>
-                                     <?php if(get_settings('public_signup') == 'enable'): ?>  
+                                     <?php if(false && get_settings('public_signup') == 'enable'): ?>  
                                         <?php if($this->session->userdata('user_id')): ?>
                                           <a  href="<?php echo site_url('user/become_an_instructor'); ?>"><?php echo site_phrase('join_now'); ?></a>
                                           <?php else: ?>

--- a/application/views/frontend/default-new/home_5.php
+++ b/application/views/frontend/default-new/home_5.php
@@ -651,7 +651,7 @@
                                 <!-- <img loading="lazy" src="<?php echo base_url('assets/frontend/default-new/image/2.png')?>"> -->
                                 <h1><?php echo site_phrase('join_now_to_start_learning'); ?></h1>
                                 <p><?php echo site_phrase('Learn from our quality instructors!')?> </p>
-                                 <?php if(get_settings('public_signup') == 'enable'): ?>  
+                                 <?php if(false && get_settings('public_signup') == 'enable'): ?>  
                                     <a href="<?php echo site_url('sign_up'); ?>"><?php echo site_phrase('get_started'); ?></a>
                                   <?php endif;?>
                             </div>
@@ -671,7 +671,7 @@
                                   <!-- <img loading="lazy" src="<?php echo base_url('assets/frontend/default-new/image/2.png')?>"> -->
                                     <h1><?php echo site_phrase('become_a_new_instructor'); ?></h1>
                                     <p><?php echo site_phrase('Teach_thousands_of_students_and_earn_money!')?> </p>
-                                      <?php if(get_settings('public_signup') == 'enable'): ?>  
+                                      <?php if(false && get_settings('public_signup') == 'enable'): ?>  
                                           <?php if($this->session->userdata('user_id')): ?>
                                             <a  href="<?php echo site_url('user/become_an_instructor'); ?>"><?php echo site_phrase('join_now'); ?></a>
                                             <?php else: ?>

--- a/application/views/frontend/default-new/home_6.php
+++ b/application/views/frontend/default-new/home_6.php
@@ -39,7 +39,7 @@
           </h4>
           <p class="info  animate__animated  animate__fadeInUp " data-wow-duration="1000" data-wow-delay="500"><?php echo site_phrase(get_frontend_settings('banner_sub_title')); ?></p>
 
-           <?php if(get_settings('public_signup') == 'enable'): ?>  
+           <?php if(false && get_settings('public_signup') == 'enable'): ?>  
           <a href="<?php echo site_url('sign_up'); ?>" class="btn-six  animate__animated  animate__fadeInUp " data-wow-duration="1000" data-wow-delay="500"><?php echo get_phrase('Join for free'); ?></a>
              <?php endif;?>
         </div>
@@ -695,7 +695,7 @@
                                
                                 <h1><?php echo site_phrase('join_now_to_start_learning'); ?></h1>
                                 <p><?php echo site_phrase('Learn from our quality instructors!')?> </p>
-                                 <?php if(get_settings('public_signup') == 'enable'): ?>  
+                                 <?php if(false && get_settings('public_signup') == 'enable'): ?>  
                                     <a href="<?php echo site_url('sign_up'); ?>"><?php echo site_phrase('get_started'); ?></a>
                                    <?php endif;?>
                             </div>
@@ -714,7 +714,7 @@
                                 <div class="student-body-text">
                                     <h1><?php echo site_phrase('become_a_new_instructor'); ?></h1>
                                     <p><?php echo site_phrase('Teach_thousands_of_students_and_earn_money!')?> </p>
-                                       <?php if(get_settings('public_signup') == 'enable'): ?>  
+                                       <?php if(false && get_settings('public_signup') == 'enable'): ?>  
                                             <?php if($this->session->userdata('user_id')): ?>
                                               <a  href="<?php echo site_url('user/become_an_instructor'); ?>"><?php echo site_phrase('join_now'); ?></a>
                                               <?php else: ?>

--- a/application/views/frontend/default-new/home_7.php
+++ b/application/views/frontend/default-new/home_7.php
@@ -891,7 +891,7 @@
                                 <!-- <img loading="lazy" src="<?php echo base_url('assets/frontend/default-new/image/2.png')?>"> -->
                                 <h1><?php echo site_phrase('join_now_to_start_learning'); ?></h1>
                                 <p><?php echo site_phrase('Learn from our quality instructors!')?> </p>
-                                 <?php if(get_settings('public_signup') == 'enable'): ?>  
+                                 <?php if(false && get_settings('public_signup') == 'enable'): ?>  
                                       <a href="<?php echo site_url('sign_up'); ?>"><?php echo site_phrase('get_started'); ?></a>
                                   <?php endif;?>
                             </div>
@@ -911,7 +911,7 @@
                                   <!-- <img loading="lazy" src="<?php echo base_url('assets/frontend/default-new/image/2.png')?>"> -->
                                     <h1><?php echo site_phrase('become_a_new_instructor'); ?></h1>
                                     <p><?php echo site_phrase('Teach_thousands_of_students_and_earn_money!')?> </p>
-                                        <?php if(get_settings('public_signup') == 'enable'): ?>  
+                                        <?php if(false && get_settings('public_signup') == 'enable'): ?>  
                                             <?php if($this->session->userdata('user_id')): ?>
                                             <a  href="<?php echo site_url('user/become_an_instructor'); ?>"><?php echo site_phrase('join_now'); ?></a>
                                             <?php else: ?>

--- a/application/views/frontend/default-new/logged_in_header.php
+++ b/application/views/frontend/default-new/logged_in_header.php
@@ -167,7 +167,9 @@
                             </div>
                         </li>
                         <li><a href="<?php echo site_url('login'); ?>"  class="sign-in-log">Login</a></li>
+                        <?php if(false): ?>
                         <li><a href="<?php echo site_url('sign_up'); ?>" class="sign-up-btn">Sign Up</a></li>
+                        <?php endif; ?>
                     </ul>    
                 </div> 
             </div>
@@ -186,7 +188,9 @@
                 <div class="offcanvas-header">
                     <button type="button" class="btn-close" data-bs-dismiss="offcanvas" aria-label="Close"><i class="fa-solid fa-xmark"></i></button>
                     <div class="offcanves-btn">
+                            <?php if(false): ?>
                             <a href="<?php echo site_url('sign_up'); ?>" class="signUp-btn"><?php echo site_phrase('sign_up')?></a>
+                            <?php endif; ?>
                         <a href="<?php echo site_url('login'); ?>"  class="logIn-btn"><?php echo site_phrase('Login')?></a>
                         
                     </div>

--- a/application/views/frontend/default-new/logged_out_header.php
+++ b/application/views/frontend/default-new/logged_out_header.php
@@ -167,7 +167,9 @@
                             </div>
                         </li>
                         <li><a href="<?php echo site_url('login'); ?>"  class="sign-in-log">Login</a></li>
+                        <?php if(false): ?>
                         <li><a href="<?php echo site_url('sign_up'); ?>" class="sign-up-btn">Sign Up</a></li>
+                        <?php endif; ?>
                     </ul>    
                 </div> 
             </div>
@@ -186,8 +188,10 @@
                 <div class="offcanvas-header">
                     <button type="button" class="btn-close" data-bs-dismiss="offcanvas" aria-label="Close"><i class="fa-solid fa-xmark"></i></button>
                     <div class="offcanves-btn">
+                            <?php if(false): ?>
                             <a href="<?php echo site_url('sign_up'); ?>" class="signUp-btn"><?php echo site_phrase('sign_up')?></a>
-                        <a href="<?php echo site_url('login'); ?>"  class="logIn-btn"><?php echo site_phrase('Login')?></a>
+                            <?php endif; ?>
+                            <a href="<?php echo site_url('login'); ?>"  class="logIn-btn"><?php echo site_phrase('Login')?></a>
                         
                     </div>
                 </div>

--- a/application/views/frontend/default-new/login.php
+++ b/application/views/frontend/default-new/login.php
@@ -50,7 +50,7 @@
                         </div>
                         <?php endif; ?>
                     </form>
-                    <?php if(get_settings('public_signup') == 'enable'): ?>      
+                    <?php if(false && get_settings('public_signup') == 'enable'): ?>      
                     <div class="another text-center">
                         <p>
                             <?php echo get_phrase('Don`t have an account?') ?>


### PR DESCRIPTION
Summary:
Hide all public signup CTAs/links across headers, home pages, login page, and footer.
Keep signup code intact but wrapped so it doesn’t render.
Test plan:
Not run (UI check recommended: homepage, header, login page).